### PR TITLE
quick fix to support lesson downloads through tor

### DIFF
--- a/app/src/org/storymaker/app/AppConstants.java
+++ b/app/src/org/storymaker/app/AppConstants.java
@@ -41,7 +41,7 @@ public final static String TAG = "StoryMaker";
 	
 	
 	public final static String TOR_PROXY_HOST = "localhost";
-	public final static int TOR_PROXY_PORT = 9050;
+	public final static int TOR_PROXY_PORT = 8118;
 	
 	
 	public final static class MimeTypes {

--- a/app/src/org/storymaker/app/lessons/LessonManager.java
+++ b/app/src/org/storymaker/app/lessons/LessonManager.java
@@ -239,7 +239,7 @@ public class LessonManager implements Runnable {
 
             boolean useTor = settings.getBoolean("pusetor", false);
             if (useTor) {
-                httpClient.useProxy(true, "SOCKS", AppConstants.TOR_PROXY_HOST, AppConstants.TOR_PROXY_PORT);
+                httpClient.useProxy(true, "HTTP", AppConstants.TOR_PROXY_HOST, AppConstants.TOR_PROXY_PORT);
             } else {
                 httpClient.useProxy(false, null, null, -1);
             }
@@ -295,7 +295,7 @@ public class LessonManager implements Runnable {
 
                         Log.d(TAG, "Loading lesson zip: " + sUrlLesson);
 
-                        if (useDownloadManager) {
+                        if (useDownloadManager && !useTor) { // downloading with manager bypasses tor
                             URI urlLesson = new URI(sUrlLesson);
                             String fileName = urlLesson.getPath();
                             fileName = fileName.substring(fileName.lastIndexOf('/') + 1);


### PR DESCRIPTION
the onionkit http client class no longer supports socks proxies so it was necessary to switch it to http to restore the ability to download lessons using tor.